### PR TITLE
Integrate Custom Domain & Configure Ingress Controller for Traffic Routing

### DIFF
--- a/Kubernetes-Manifest-Files/Backend-ingress/backend-ingress.yaml
+++ b/Kubernetes-Manifest-Files/Backend-ingress/backend-ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: backend-ingress
   namespace: three-tier
   annotations:
-    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/scheme: internal-facing
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
     alb.ingress.kubernetes.io/subnets: ""

--- a/Kubernetes-Manifest-Files/Backend-ingress/backend-ingress.yaml
+++ b/Kubernetes-Manifest-Files/Backend-ingress/backend-ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: backend-ingress
+  namespace: three-tier
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
+    alb.ingress.kubernetes.io/subnets: ""
+spec:
+  ingressClassName: alb
+  rules:
+    - host: api.nausicaaglobalgreen.live
+      http:
+        paths:
+          - path: /api/
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8080

--- a/Kubernetes-Manifest-Files/Backend/deployment.yaml
+++ b/Kubernetes-Manifest-Files/Backend/deployment.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: three-tier
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      imagePullSecrets:
+        - name: docker-registry-secret # Pull secret for private registry
+      containers:
+        - name: backend
+          image: vinay2806/backend:1.0
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "200m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          env:
+            - name: SPRING_DATASOURCE_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: backend-config
+                  key: SPRING_DATASOURCE_URL
+            - name: SPRING_DATASOURCE_DRIVER_CLASS_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: backend-config
+                  key: SPRING_DATASOURCE_DRIVER_CLASS_NAME
+            - name: SPRING_PROFILE
+              valueFrom:
+                configMapKeyRef:
+                  name: backend-config
+                  key: SPRING_PROFILE
+            - name: SPRING_DATASOURCE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-secret
+                  key: SPRING_DATASOURCE_USERNAME
+            - name: SPRING_DATASOURCE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-secret
+                  key: MYSQL_ROOT_PASSWORD
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-secret
+                  key: JWT_SECRET
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /actuator/health # Health check endpoint
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /actuator/health # Health check endpoint
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /api/grants # Custom health check endpoint
+              port: 8080
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            failureThreshold: 30

--- a/Kubernetes-Manifest-Files/Backend/service.yaml
+++ b/Kubernetes-Manifest-Files/Backend/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: three-tier
+spec:
+  selector:
+    app: backend
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP

--- a/Kubernetes-Manifest-Files/Database/configmap.yaml
+++ b/Kubernetes-Manifest-Files/Database/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backend-config
+  namespace: three-tier
+data:
+  SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/nausicaa_global_green_db
+  MYSQL_DATABASE: nausicaa_global_green_db
+  SPRING_PROFILE: development
+  SPRING_DATASOURCE_DRIVER_CLASS_NAME: com.mysql.cj.jdbc.Driver

--- a/Kubernetes-Manifest-Files/Database/deployment.yaml
+++ b/Kubernetes-Manifest-Files/Database/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+  namespace: three-tier
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: mysql
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+        - name: mysql
+          image: mysql:8.0
+          env:
+            - name: MYSQL_DATABASE
+              valueFrom:
+                configMapKeyRef:
+                  name: backend-config
+                  key: MYSQL_DATABASE
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-secret
+                  key: MYSQL_ROOT_PASSWORD
+          ports:
+            - containerPort: 3306
+          volumeMounts:
+            - mountPath: "/var/lib/mysql"
+              name: mysql-storage
+            - mountPath: /docker-entrypoint-initdb.d/init.sql
+              subPath: init.sql
+              name: init-script
+      volumes:
+        - name: mysql-storage
+          persistentVolumeClaim:
+            claimName: mysql-pvc
+        - name: init-script
+          configMap:
+            name: sql-configmap # This refers to the ConfigMap we created
+            items:
+              - key: init.sql
+                path: init.sql

--- a/Kubernetes-Manifest-Files/Database/dockersecret.yaml
+++ b/Kubernetes-Manifest-Files/Database/dockersecret.yaml
@@ -1,0 +1,11 @@
+# the below command is to encrypt the dockerhub username and password
+# echo -n '{"auths":{"https://hub.docker.com":{"username":"YOUR_USERNAME","password":"YOUR_PASSWORD","auth":"'"$(echo -n 'YOUR_USERNAME:YOUR_PASSWORD' | base64)"'"}}}' | base64 -w 0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: docker-registry-secret
+  namespace: three-tier
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: >
+    eyJhdXRocyI6eyJodHRwczovL2h1Yi5kb2NrZXIuY29tIjp7InVzZXJuYW1lIjoidmluYXkyODA2IiwicGFzc3dvcmQiOiJBbmFuZEAxMjMiLCJhdXRoIjoiZG1sdVlYa3lPREEyT2tGdVlXNWtRREV5TXc9PSJ9fX0=

--- a/Kubernetes-Manifest-Files/Database/pv.yaml
+++ b/Kubernetes-Manifest-Files/Database/pv.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: mysql-pv
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/mnt/data"

--- a/Kubernetes-Manifest-Files/Database/pvc.yaml
+++ b/Kubernetes-Manifest-Files/Database/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-pvc
+  namespace: three-tier
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/Kubernetes-Manifest-Files/Database/secret.yaml
+++ b/Kubernetes-Manifest-Files/Database/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-secret
+  namespace: three-tier
+type: Opaque
+data:
+  MYSQL_ROOT_PASSWORD: password
+  SPRING_DATASOURCE_USERNAME: root
+  JWT_SECRET: secret

--- a/Kubernetes-Manifest-Files/Database/service.yaml
+++ b/Kubernetes-Manifest-Files/Database/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  namespace: three-tier
+spec:
+  ports:
+    - port: 3306
+      targetPort: 3306
+  type: ClusterIP
+  selector:
+    app: mysql

--- a/Kubernetes-Manifest-Files/Database/sql-configmap.yaml
+++ b/Kubernetes-Manifest-Files/Database/sql-configmap.yaml
@@ -1,0 +1,103 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sql-configmap
+  namespace: three-tier
+data:
+  init.sql: |
+    CREATE DATABASE IF NOT EXISTS nausicaa_global_green_db;
+
+    USE nausicaa_global_green_db;
+
+    -- nausicaa_global_green_db.grants definition
+
+    CREATE TABLE `grants` (
+
+      `grant_id` int NOT NULL AUTO_INCREMENT,
+
+      `grant_name` varchar(255) NOT NULL,
+
+      `amount` varchar(255) NOT NULL,
+
+      `description` varchar(255) NOT NULL,
+
+      `eligibility` varchar(255) NOT NULL,
+
+      PRIMARY KEY (`grant_id`)
+
+    ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+
+    -- nausicaa_global_green_db.user_details definition
+
+    CREATE TABLE `user_details` (
+
+      `first_name` varchar(255) NOT NULL,
+
+      `user_id` int NOT NULL AUTO_INCREMENT,
+
+      `last_name` varchar(255) NOT NULL,
+
+      `email` varchar(255) NOT NULL,
+
+      `password` varchar(255) NOT NULL,
+
+      `last_login` varchar(255) DEFAULT NULL,
+
+      `is_admin` bit(1) NOT NULL,
+
+      PRIMARY KEY (`user_id`),
+
+      UNIQUE KEY `user_details_unique` (`email`)
+
+    ) ENGINE=InnoDB AUTO_INCREMENT=15 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+
+
+    -- nausicaa_global_green_db.application_details definition
+
+    CREATE TABLE `application_details` (
+      `application_id` int NOT NULL AUTO_INCREMENT,
+      `user_id` int NOT NULL,
+      `organization_name` varchar(255) NOT NULL,
+      `grant_id` int NOT NULL,
+      `application_status` varchar(255) NOT NULL,
+      `approval_date` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+      `requested_amount` varchar(255) NOT NULL,
+      `project_description` varchar(255) NOT NULL,
+      `admin_comments` varchar(255) DEFAULT NULL,
+      PRIMARY KEY (`application_id`),
+      KEY `application_details_user_details_FK` (`user_id`),
+      KEY `application_details_grants_FK` (`grant_id`),
+      CONSTRAINT `application_details_grants_FK` FOREIGN KEY (`grant_id`) REFERENCES `grants` (`grant_id`),
+      CONSTRAINT `application_details_user_details_FK` FOREIGN KEY (`user_id`) REFERENCES `user_details` (`user_id`)
+    ) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+    -- nausicaa_global_green_db.contact_us definition
+
+    CREATE TABLE `contact_us` (
+      `query_id` int NOT NULL AUTO_INCREMENT,
+      `name` varchar(255) NOT NULL,
+      `email` varchar(255) NOT NULL,
+      `phone` varchar(255) NOT NULL,
+      `message` varchar(255) NOT NULL,
+      PRIMARY KEY (`query_id`)
+    ) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+    INSERT INTO nausicaa_global_green_db.grants
+    (grant_id, grant_name, amount, description, eligibility)
+    VALUES(1, 'Teto', '10000', 'For climate change Initiatives', 'NA');
+    INSERT INTO nausicaa_global_green_db.grants
+    (grant_id, grant_name, amount, description, eligibility)
+    VALUES(2, 'Pejite Innovation', '5000', 'For climate change Initiatives', 'NA');
+
+    INSERT INTO nausicaa_global_green_db.user_details
+    (first_name, user_id, last_name, email, password, last_login, is_admin)
+    VALUES('Athul', 1, 'S', 'athul@gmail.com', 'xxxxxx', NULL, 1);
+    INSERT INTO nausicaa_global_green_db.user_details
+    (first_name, user_id, last_name, email, password, last_login, is_admin)
+    VALUES('helena', 2, 'g', 'helenag@gmail.com', '3zCaAhu45v2Z9gImNSv9pGDut7Ch2Q+NFbM4xbxLNM0=', '2025-01-29T00:26:37.240Z', 0);
+
+    INSERT INTO nausicaa_global_green_db.application_details
+    (application_id, user_id, organization_name, grant_id, application_status, approval_date, requested_amount, project_description)
+    VALUES(1, 2, 'ATU', 1, 'In Progress', '21/01/2024', '10000', '');

--- a/Kubernetes-Manifest-Files/Frontend-ingress/frontend-ingress.yaml
+++ b/Kubernetes-Manifest-Files/Frontend-ingress/frontend-ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend-ingress
+  namespace: three-tier
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
+    alb.ingress.kubernetes.io/subnets: ""
+spec:
+  ingressClassName: alb
+  rules:
+    - host: www.nausicaaglobalgreen.live
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 4200

--- a/Kubernetes-Manifest-Files/frontend/deployment.yaml
+++ b/Kubernetes-Manifest-Files/frontend/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: three-tier
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      imagePullSecrets:
+        - name: docker-registry-secret # This is the secret of the docker registry
+      containers:
+        - name: frontend
+          image: vinay2806/frontend:2.0
+          env:
+            - name: ANGULAR_APP_BACKEND_URL
+              value: "http://api.nausicaaglobalgreen.live/api/" # This is the backend URL
+          ports:
+            - containerPort: 4200

--- a/Kubernetes-Manifest-Files/frontend/service.yaml
+++ b/Kubernetes-Manifest-Files/frontend/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: three-tier
+spec:
+  selector:
+    app: frontend
+  ports:
+    - protocol: TCP
+      port: 4200
+      targetPort: 4200
+  type: ClusterIP

--- a/eks-cluster/module/vpc.tf
+++ b/eks-cluster/module/vpc.tf
@@ -38,7 +38,8 @@ resource "aws_subnet" "public-subnet" {
     Name                                          = "${var.pub-sub-name}-${count.index + 1}"
     Env                                           = var.env
     "kubernetes.io/role/elb"                      = "1"
-    "kubernetes.io/cluster/${local.cluster-name}"  = "shared"
+    "kubernetes.io/role/alb-ingress"              = "1"
+    "kubernetes.io/cluster/${local.cluster-name}" = "shared"
   }
 
   depends_on = [aws_vpc.vpc,
@@ -56,7 +57,7 @@ resource "aws_subnet" "private-subnet" {
     Name                                          = "${var.pri-sub-name}-${count.index + 1}"
     Env                                           = var.env
     "kubernetes.io/role/internal-elb"             = "1"
-    "kubernetes.io/cluster/${local.cluster-name}"  = "shared"
+    "kubernetes.io/cluster/${local.cluster-name}" = "shared"
   }
 
   depends_on = [aws_vpc.vpc,

--- a/green-global-initiative-api/docker-compose.yml
+++ b/green-global-initiative-api/docker-compose.yml
@@ -8,8 +8,6 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: nausicaa_global_green_db
-      MYSQL_USER: root
-      MYSQL_PASSWORD: password
     ports:
       - "3307:3306"
     networks:
@@ -36,8 +34,8 @@ services:
     environment:
       SPRING_DATASOURCE_URL: jdbc:mysql://mysql_db:3306/nausicaa_global_green_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
       SPRING_PROFILE: development  # Set the profile at runtime
-      DB_USERNAME: root
-      DB_PASSWORD: password
+      SPRING_DATASOURCE_USERNAME: root
+      SPRING_DATASOURCE_PASSWORD: password
       JWT_SECRET: secret
     ports:
       - "8080:8080"

--- a/green-global-initiative-api/pom.xml
+++ b/green-global-initiative-api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>

--- a/green-global-initiative-api/src/main/resources/application-development.properties
+++ b/green-global-initiative-api/src/main/resources/application-development.properties
@@ -1,8 +1,8 @@
 spring.application.name=nausicaa_green_initiative
-spring.datasource.url=jdbc:mysql://mysql_db:3306/nausicaa_global_green_db
-spring.datasource.username=${DB_USERNAME}
-spring.datasource.password=${DB_PASSWORD}
-spring.datasource.driver-class-name=com.mysql.jdbc.Driver
+spring.datasource.url=jdbc:mysql://mysql:3306/nausicaa_global_green_db
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 jwt_secret=${JWT_SECRET}

--- a/green-global-initiative-api/src/main/resources/application-production.properties
+++ b/green-global-initiative-api/src/main/resources/application-production.properties
@@ -1,8 +1,8 @@
 spring.application.name=nausicaa_green_initiative
-spring.datasource.url=jdbc:mysql://mysql_db:3306/nausicaa_global_green_db
-spring.datasource.username=${DB_USERNAME}
-spring.datasource.password=${DB_PASSWORD}
-spring.datasource.driver-class-name=com.mysql.jdbc.Driver
+spring.datasource.url=jdbc:mysql://mysql:3306/nausicaa_global_green_db
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 jwt_secret=${JWT_SECRET}


### PR DESCRIPTION
This PR integrates a custom domain name into the Kubernetes manifest and configures the Ingress controller to ensure proper traffic routing. The changes include:

Adding an Ingress resource for routing frontend and backend traffic.
Associating the domain nausicaaglobalgreeninitiative.live with the respective services (api.nausicaaglobalgreeninitiative.live for backend, www.nausicaaglobalgreeninitiative.live for frontend).
Configuring TLS for secure HTTPS access.
Ensuring seamless integration with AWS Load Balancer and Route 53 for DNS resolution.